### PR TITLE
English improvements for the first 3 lessons

### DIFF
--- a/answers.tex
+++ b/answers.tex
@@ -27,22 +27,22 @@ What is usually not allowed before or after a separator? && Another separator. \
 \label{'basic_sentences'}
 %
 \begin{supertabular}{p{5,5cm}|ll}
-What is a verb && A verb describes an action. \\ % no-dictionary
+What is a verb? && A verb specifies an action. \\ % no-dictionary
 What is a noun? &&  A noun is a word for a person, place or thing. \\ % no-dictionary
 What is \textit{li} used for?  &&  It separates the subject phrase from the predicate phrase.  \\ % no-dictionary
 What does a personal pronoun replace? && It replaces a noun. \\ % no-dictionary
-How to recognize nouns, pronouns, verbs and adjectives in \textit{toki pona}? && At their position in the sentence. \\ % no-dictionary
+How do you recognize nouns, pronouns, verbs and adjectives in Toki Pona? && By their positions in the sentence. \\ % no-dictionary
 What is a subject?  &&   The subject is the carrier of the action, process or state. \\ % no-dictionary
 After which subject phrases is \textit{li} not used?  &&   It is only used if the subject phrase is not \textit{mi} or \textit{sina}. \\ % no-dictionary
-Where does the subject stand in the sentence?  &&  In Toki Pona it is always at the beginning of the sentence. \\ % no-dictionary
+Where does the subject stand in a sentence?  &&  In Toki Pona it is always at the beginning of the sentence. \\ % no-dictionary
 Can an empty verb slot alone form a predicate? && No!  \\ % no-dictionary
 When can a verb slot be empty?  &&   If the predicate is formed by a noun or adjective.  \\ % no-dictionary
-What is a predicate?  &&   It is a core element in a sentence and the statement of the sentence. \\ % no-dictionary
-A complete sentence in \textit{toki pona} always contains\dots  &&  a subject and a predicate phrase.  \\ % no-dictionary
-What kinds of words can be used in \textit{toki pona} to form a predicate? && Verbs, nouns or adjectives.  \\ % no-dictionary
+What is a predicate?  &&   It is a core element of a sentence and forms the statement of the sentence. \\ % no-dictionary
+What does a complete sentence in Toki Pona always contain?  &&  A subject phrase and a predicate phrase.  \\ % no-dictionary
+What kinds of words can be used in Toki Pona to form a predicate? && Verbs, nouns or adjectives.  \\ % no-dictionary
 What is an adjective?  &&  An adjective is a word that describes a noun.  \\ % no-dictionary
-Where are possible adjective slots?  &&  After a noun, after a pronoun and according to \textit{li}. \\  % no-dictionary
-Why can't a sentence be ended after \textit{li}? && Because then the predicate is missing. \\ % no-dictionary
+Where are the possible adjective slots?  &&  After a noun, after a pronoun and after \textit{li}. \\  % no-dictionary
+Why can't a sentence end with \textit{li}? && Because then the predicate is missing. \\ % no-dictionary
 \end{supertabular} 
 
 \begin{supertabular}{p{5,5cm}|ll}

--- a/basic_sentences.tex
+++ b/basic_sentences.tex
@@ -15,7 +15,7 @@
  && \\ % no-dictionary
 %
 \index{\textit{li}} 
-\textbf{\dots li \dots} && \textit{separator}: It separates the subject phrase, except 'mi' and 'sina', from the predicate phrase. \\ && Don't use 'li' before or after an other separator. \\ % no-dictionary
+\textbf{\dots li \dots} && \textit{separator}: It separates the subject phrase, except `mi' and `sina', from the predicate phrase. \\ && Don't use `li' before or after an other separator. \\ % no-dictionary
  && \\ % no-dictionary
 %
 \index{\textit{mi}} 
@@ -33,14 +33,14 @@
 %
 \index{\textit{ona}}
 \textbf{ona} && \textit{personal pronoun}: she, he, it, they \\ % no-dictionary
-\textbf{\dots ona} && \textit{possessive pronoun}: her, his, its \\  % no-dictionary
+\textbf{\dots ona} && \textit{possessive pronoun}: her, his, its, theirs \\  % no-dictionary
 \textbf{\dots e ona} && \textit{reflexive pronoun}: himself, herself, itself, themselves \\  
  && \\ % no-dictionary
 %  
 \index{\textit{pona}}
 \textbf{\dots pona} && \textit{adjective}: good, simple, positive, nice, correct, right \\ % no-dictionary
 \textbf{\dots pona} && \textit{adverb}: good, simple, positive, nice, correct, right \\ % no-dictionary
-\textbf{pona} && \textit{noun}: good, simplicity, positivity \\ % no-dictionary
+\textbf{pona} && \textit{noun}: goodness, simplicity, positivity \\ % no-dictionary
 \textbf{pona (e \dots)} && \textit{verb transitive}: to improve, to fix, to repair, to make good \\ % no-dictionary
  && \\ % no-dictionary
 %
@@ -51,24 +51,24 @@
  && \\ % no-dictionary
 %
 \index{\textit{suno}}
-\textbf{\dots suno} && \textit{adjective}: sunny, sunnily \\ % no-dictionary
-\textbf{\dots suno} && \textit{adverb}: sunny, sunnily \\ % no-dictionary
-\textbf{suno} && \textit{noun}: sun, light \\ % no-dictionary
-\textbf{suno (e \dots)} && \textit{verb transitive}: to light, to illumine \\ % no-dictionary
+\textbf{\dots suno} && \textit{adjective}: sunny, bright \\ % no-dictionary
+\textbf{\dots suno} && \textit{adverb}: sunny, bright \\ % no-dictionary
+\textbf{suno} && \textit{noun}: sun, light, brightness, light source \\ % no-dictionary
+\textbf{suno (e \dots)} && \textit{verb transitive}: to light, to illumine, to shine \\ % no-dictionary
  && \\ % no-dictionary
 %
 \index{\textit{suli}}
 \textbf{\dots suli} && \textit{adjective}: big, tall, long, adult, important \\ % no-dictionary
 \textbf{\dots suli} && \textit{adverb}: big, tall, long, adult, important \\ % no-dictionary
-\textbf{suli} && \textit{noun}: size \\ % no-dictionary
+\textbf{suli} && \textit{noun}: bigness, size \\ % no-dictionary
 \textbf{suli (e \dots)} && \textit{verb transitive}: to enlarge, to lengthen \\ % no-dictionary
  && \\ % no-dictionary
 %
 \index{\textit{telo}}
-\textbf{\dots telo} && \textit{adjective}: wett, slobbery, moist, damp, humid, sticky, sweaty, dewy, drizzly \\ % no-dictionary
-\textbf{\dots telo} && \textit{adverb}: wett, slobbery, moist, damp, humid, sticky, sweaty, dewy, drizzly \\ % no-dictionary
+\textbf{\dots telo} && \textit{adjective}: wet, moist, damp, humid, sticky, sweaty, slobbery, dewy, drizzly \\ % no-dictionary
+\textbf{\dots telo} && \textit{adverb}: wet, moist, damp, humid, sticky, sweaty, slobbery, dewy, drizzly \\ % no-dictionary
 \textbf{telo} && \textit{noun}: water, liquid, juice, sauce \\ % no-dictionary
-\textbf{telo (e \dots)} && \textit{verb transitive}: to water, to wash with water, to put water to, to melt, to liquify \\ % no-dictionary
+\textbf{telo (e \dots)} && \textit{verb transitive}: to water, to wash, to put water to, to melt, to liquify \\ % no-dictionary
  && \\ % no-dictionary
 %
 \index{apostrophe}
@@ -85,29 +85,28 @@
 %
 \index{\textit{suli}}
 Do you see how several of the words in the vocabulary have multiple meanings? 
-For example, \textit{suli} can mean either 'long', 'tall', 'big', 'important' or 'the size'. 
-By now, you might be wondering, 'What's going on? How can one word mean so many different things?' 
+For example, \textit{suli} can mean either `long', `tall', `big', `important' or `the size'. 
+By now, you might be wondering, `What's going on? How can one word mean so many different things?' 
 
 Welcome to the world of Toki Pona! The truth is that lots of words are like this in Toki Pona. 
 Because the language has such a small vocabulary and is so basic, the ambiguity is inevitable. 
-However, this vagueness is not necessarily a bad thing. Because of the vagueness, a speaker of Toki Pona is forced to focus on the very basic, unaltered aspect of things, rather than focusing on many minute details. 
+However, this vagueness is not necessarily a bad thing. Because of the vagueness, a speaker of Toki Pona is forced to focus on the very basic, unaltered essence of things, rather than focusing on many minute details. 
 
 \index{singular}
 \index{plural}
-Another way that Toki Pona is ambiguous is that it can not specify whether a word is singular or plural. 
-For example, \textit{jan} can mean either 'person' or 'people'. 
+Another way that Toki Pona is ambiguous is that it does not specify whether a word is singular or plural. 
+For example, \textit{jan} can mean either `person' or `people'. 
 If you've decided that Toki Pona is too arbitrary and that not having plurals is simply the final straw, don't be so hasty. 
 Toki Pona is not the only language that doesn't specify whether a noun is plural or not. 
 Japanese, for example, does the same thing. 
 
 \index{Tense}
-Toki Pona has no Tenses. 
+Toki Pona has no tenses. 
 The verbs don't change. 
 If it's absolutely necessary, there are ways of saying that something happened in the past, present, or future. 
 
-As you can see in the vocabulary list, most words can be used in different word types. 
-They remain unchanged. 
-The word type is derived from the position in the sentence. 
+As you can see in the vocabulary list, most words take on multiple word types or parts of speech. 
+The words remain unchanged, so the word type is derived from its position in the sentence. 
 In this lesson, we will deal with nouns, pronouns, verbs, adjectives and a special separator. 
 
 \index{noun}
@@ -115,16 +114,16 @@ In this lesson, we will deal with nouns, pronouns, verbs, adjectives and a speci
 \index{verb}
 A noun is a word for a person, place or thing. 
 An adjective is a word that describes a noun. 
-A verb describes an action. 
+A verb specifies an action. 
 
 \index{pronoun}
 \index{pronoun!personal}
 \index{pronoun!possessive}
 Pronouns are proxies for different types of words. 
-They are used in the same place as the word to be represented and have the same grammatical characteristics as this one.
+They are used in the same place as the word to be represented and have the same grammatical characteristics.
 Pronouns are not words of content, but they denote persons or things by referring to the context. 
-Personal pronouns (I, you, \dots) represent nouns. 
-Possessive pronouns (my, your, \dots) represent adjectives. 
+Personal pronouns (I, you, it, \dots) represent nouns. 
+Possessive pronouns (my, your, its, \dots) represent adjectives. 
 In the next few lessons we will learn more about other types of pronouns. 
 
 % 
@@ -141,9 +140,9 @@ In the next few lessons we will learn more about other types of pronouns.
 \index{\textit{moku}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-With the personal pronoun \textit{mi} or the personal pronoun \textit{sina} at the beginning and a subsequent verb a simple sentence in Toki Pona is already complete. 
+With the personal pronoun \textit{mi} or the personal pronoun \textit{sina} followed by a verb, a simple sentence in Toki Pona is already complete. 
 A declarative sentence ends with a full stop. 
-Toki Pona has no nested subordinate clauses and nearly no commas. 
+Toki Pona has no nested subordinate clauses and hardly any commas. 
 
 \begin{supertabular}{p{5,5cm}|ll}
 mi moku. && I eat. \\
@@ -151,13 +150,14 @@ sina pona. && You fix. \\
 \end{supertabular} 
 
 \index{subject phrase}
-In these sentences personal pronouns \textit{mi} and \textit{sina} are in each case the subject phrase. 
+In these sentences the personal pronouns \textit{mi} and \textit{sina} are in each case the subject phrase. 
 In Toki Pona, a subject phrase is always at the beginning of the sentence. 
 In these examples, the subject phrases consist of only one subject (\textit{mi} or \textit{sina}).
 
 The subject is the carrier of the action, process or state. 
-It is the most important addition to the verb in the sentence, a complete sentence always contains a subject. 
-You ask for the subject with whom or what.
+It is the most important addition to the verb in a sentence. 
+A complete sentence always contains a subject. 
+In English you can ask for the subject of a sentence with `who' or `what'.
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -171,14 +171,14 @@ You ask for the subject with whom or what.
 \index{verb vs. predicate}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-The verbs \textit{moku} and \textit{pona} form the predicate phrase in these examples.  
-The predicate is a core element in a sentence and is the statement of the sentence. 
-No statement sentence is possible without a predicate. 
+The verbs \textit{moku} and \textit{pona} form the predicate phrase in the previous two examples. 
+The predicate is a core element in a sentence and forms the statement of the sentence. 
+No statement sentence is possible without a predicate.
 
 In most languages, a predicate is formed by a verb, but this is not mandatory in all languages. 
-As we will soon see, in Toki Pona the predicate is not necessarily formed by a verb. 
-The difference between verb and predicate is that verb designates a word part and predicate designates a grammatical function.
-A predicate and possible objects form a predicate phrase. 
+As we'll soon see, in Toki Pona the predicate is not necessarily formed by a verb. 
+The difference between a verb and a predicate is that a verb is a word type and a predicate is a grammatical function. 
+A predicate and its objects (if it has any) form a predicate phrase.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Nouns or Adjectives as Predicates}
@@ -201,25 +201,25 @@ A predicate and possible objects form a predicate phrase.
 \index{copula}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-One of the first principles you'll need to learn about Toki Pona is that there is no form of the static verb 'to be' like there is in English. 
-That's why the verb slot can be empty and after \textit{mi} or \textit{sina} can follow also a noun or adjective. 
-In these lessons, the term 'slot' is used to indicate a valid position of a word type in the sentence.
+One of the first principles you'll need to learn about Toki Pona is that there is no form of the static verb `to be' like there is in English. 
+That's why the verb slot can be empty and \textit{mi} or \textit{sina} can be followed by a noun or adjective. 
+In these lessons, the term `slot' is used to indicate a valid position of a word type in a sentence.
 
-Regular sentences can also be formed in other languages without a verb appearing in them. 
+Other languages also allow ordinary sentences to be formed without a verb appearing in them. 
 Examples are Russian and Arabic. 
-These languages are called no-copula languages. 
+These languages are called no-copula languages.
 
-A copula is a word that connects the subject and predicate ('copulates').
-If a 'normal' verb is the predicate, one does not need an additional copula.
+A copula is a word that connects the subject and predicate (`copulates').
+If a `normal' verb is the predicate, one does not need an additional copula.
 It occurs only if a noun, pronoun or adjective is the predicate.
-In English the verb 'to be' serves as the copula. 
-No-copula language, like Toki Pona, does not require a copula. 
+In English the verb `to be' serves as the copula. 
+No-copula languages, like Toki Pona, do not require a copula.
 
 A noun then functions as a predicate noun or an adjective serves as predicate adjective.
 But this noun or adjective does not become a verb. 
 An empty verb slot cannot, however, form a predicate phrase on its own. 
 A noun or adjective must follow. 
-That is, directly after \textit{mi} or \textit{sina} the sentence cannot be finished yet.
+That is, the sentence can't just end with \textit{mi} or \textit{sina}.
 
 In no-copula languages, the word form usually indicates whether the predicate is a verb, noun or adjective. 
 This is not possible in Toki Pona. 
@@ -233,11 +233,12 @@ sina pona. && You fix. \\
 sina ' pona. && You are good. \\  
 \end{supertabular} 
 
-Because Toki Pona lacks 'to be', the exact meaning is lost. 
-\textit{moku} in this sentence could be a verb, or it could be a noun; just as \textit{pona} could be an adjective or could be a verb. 
+Because Toki Pona lacks `to be', the exact meaning is lost. 
+If we ignore the apostrophes in these sentences, \textit{moku} could be a verb, or it could be a noun; just as \textit{pona} could be an adjective or a verb. 
 In situations such as these, the listener must rely on context. 
-After all, how often do you hear someone say 'I am food.'? 
-I hope not very often! You can be fairly certain that \textit{mi moku} means 'I'm eating'. 
+After all, how often do you hear someone say `I am food.'? 
+I hope not very often! 
+You can be fairly certain that \textit{mi moku} means `I'm eating'.
 
 %
 \newpage
@@ -263,10 +264,9 @@ moku li ' pona. && The food is good. \\
 ona li ' moku. && It is food. \\
 \end{supertabular} 
 
-Is the verb slot empty, after \textit{li} can follow a noun or adjective as well. 
-As already written, an empty verb slot cannot form a predicate phrase on its own. 
-A noun or adjective must follow. 
-That is, directly after \textit{li} the sentence can not yet be finished or an object can follow.
+If the verb slot empty, \textit{li} can be followed by a noun or adjective as well. 
+Remember, an empty verb slot cannot form a predicate phrase on its own; a noun or adjective must follow. 
+That means the sentence can't end with \textit{li}; a verb an object must follow.
 
 %
 \newpage
@@ -274,25 +274,25 @@ That is, directly after \textit{li} the sentence can not yet be finished or an o
 \subsection*{Practice (Answers: Page~\pageref{'basic_sentences'})}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Please write down your answers and check them afterwards. 
+Please write down your answers and check them afterwards.
 
 \begin{supertabular}{p{5,5cm}|ll}
-What is a verb &&  \\ % no-dictionary
+What is a verb? &&  \\ % no-dictionary
 What is a noun? &&   \\ % no-dictionary
 What is \textit{li} used for?  &&   \\ % no-dictionary
 What does a personal pronoun replace? &&  \\ % no-dictionary
-How to recognize nouns, pronouns, verbs and adjectives in \textit{toki pona}? &&  \\ % no-dictionary
+How do you recognize nouns, pronouns, verbs and adjectives in Toki Pona? &&  \\ % no-dictionary
 What is a subject?  &&   \\ % no-dictionary
 After which subject phrases is \textit{li} not used?  &&  \\ % no-dictionary
-Where does the subject stand in the sentence?  &&    \\ % no-dictionary
+Where does the subject stand in a sentence?  &&    \\ % no-dictionary
 Can an empty verb slot alone form a predicate? &&    \\ % no-dictionary
 When can a verb slot be empty?  &&     \\ % no-dictionary
 What is a predicate?  &&     \\ % no-dictionary
-A complete sentence in \textit{toki pona} always contains\dots  &&     \\ % no-dictionary
-What kinds of words can be used in \textit{toki pona} to form a predicate? &&   \\ % no-dictionary
+What does a complete sentence in Toki Pona always contain?  &&     \\ % no-dictionary
+What kinds of words can be used in Toki Pona to form a predicate? &&   \\ % no-dictionary
 What is an adjective?  &&    \\ % no-dictionary
-Where are possible adjective slots?  &&    \\  % no-dictionary
-Why can't a sentence be ended after \textit{li}? &&  \\ % no-dictionary
+Where are the possible adjective slots?  &&    \\  % no-dictionary
+Why can't a sentence end with \textit{li}? &&  \\ % no-dictionary
 \end{supertabular} 
 
 Which word types can represent the respective word in the sentence after the hyphen?
@@ -310,7 +310,7 @@ li - moku li ' pona. &&  \\ % no-dictionary
 \end{supertabular}
 
 Try to translate these sentences. 
-You can use the tool \textit{Toki Pona Parser} (\cite{www:rowa:02}) for spelling and grammar check. 
+You can use the \textit{Toki Pona Parser} (\cite{www:rowa:02}) to check spelling and grammar.
 
 \begin{supertabular}{p{5,5cm}|ll}
 People are good. && \\ % no-dictionary

--- a/introduction.tex
+++ b/introduction.tex
@@ -4,37 +4,37 @@
 %
 Sonja Lang created the language Toki Pona in the year 2001. 
 Her aim was minimalism. 
-Toki Pona consists of only about 120 words, which are not altered. 
-In accordance with the position in the sentence, the words can vary their significance. 
-To describe more detail you have to combine words.
+Toki Pona consists of only about 120 words, which are never altered. 
+The part of speech signified by a word varies in accordance with its position in the sentence. 
+To describe things in more detail you have to combine words.
 
 It is not the goal of Toki Pona to describe complex issues. 
-Dissertations and scientific papers will never written in Toki Pona. 
-Lawyers, bureaucrats, theologians and politicians are warned of the side-effect of this language.
+Dissertations and scientific papers will never be written in Toki Pona. 
+Lawyers, bureaucrats, theologians and politicians should be warned of the side-effects of this language.
 
-It is not the aim of Toki Pona to solve the communication problems in the world. 
+It is not the aim of Toki Pona to solve the communication problems of the world. 
 But you can learn this language in a month. 
-Toki Pona is easy in an intelligent way and yoga for the brain. 
+Toki Pona is easy in an intelligent way and it's yoga for the brain. 
 People who hate nested subordinate clauses and commas will certainly have fun with Toki Pona.
 
 Maybe only one natural language can be compared to Toki Pona. 
 It is the language of the Pirah\'{a} (\cite{www:piraha:01}). 
-For example this language has no recursion. 
+For example, this language has no recursion. 
 
 %
 %% 
 %
 Toki Pona has evolved since 2001. 
-Therefore these lessons are based on the tutorials from BJ Knight (jan Pije) \cite{www:Pije:01} (2003) and the official Toki Pona book \cite{www:tokipona.org} by Sonja Lang (2014). 
-But I tried not to take over mistakes and inaccuracies. 
+Therefore these lessons are based on the tutorials from B.\ J.\ Knight (jan Pije) \cite{www:Pije:01} (2003) and the official Toki Pona book \cite{www:tokipona.org} by Sonja Lang (2014). 
+But I tried not to carry over mistakes and inaccuracies. 
 In my lessons, great importance is attached to the presentation of grammatical rules. 
 This avoids misunderstandings due to incorrect grammar.
 
-So have fun with the lessons and learning of Toki Pona. 
+So have fun with the lessons and with learning Toki Pona. 
 Memrise helps for learning vocabulary \cite{www:memrise:01}. Links related to Toki Pona can be found on the website \cite{www:rowa:01}. 
 A dictionary can be found here \cite{www:rowa:01}. 
 
-You can use the tool \textit{Toki Pona Parser} (\cite{www:rowa:02}) for spelling, grammar check and ambiguity check of Toki Pona sentences 
+You can use the tool \textit{Toki Pona Parser} (\cite{www:rowa:02}) for checking the spelling, grammar and ambiguity of Toki Pona sentences. 
 
 
 \textit{toki pona li ' pona, tawa sina.}

--- a/pronunciation_alphabet.tex
+++ b/pronunciation_alphabet.tex
@@ -30,8 +30,6 @@ j && \textbf{y}et   \\ % no-dictionary
 \index{vowel}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Toki Pona's vowels are quite unlike English's. 
-
 Toki Pona's vowels are quite unlike English's. Whereas vowels in English are quite arbitrary and can be pronounced many different ways depending on the word, Toki Pona's vowels are all regular and never change pronunciation. 
 If you're familiar with Italian, Spanish, Esperanto, or certain other languages, then your work is already done. The vowels are the same in Toki Pona as they are in these languages. 
 
@@ -54,8 +52,8 @@ u   &&    f\textbf{oo}d   \\ % no-dictionary
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 All official Toki Pona words are never capitalized. 
-They are lowercase even at the beginning of the sentence! 
-The only time that capital letters are used is when you are using unofficial words, like the names of people or places or religions. 
+They are lowercase even at the beginning of a sentence! 
+The only time that capital letters are used is when you are using unofficial words, like the names of people, places or religions. 
 %
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -67,10 +65,10 @@ The only time that capital letters are used is when you are using unofficial wor
 
 \begin{supertabular}{p{2cm}|ll} 
 \textbf{.} && \textit{separator}: A declarative sentence ends with a full stop. \\ % no-dictionary
-\textbf{!} && \textit{separator}: An imperative or an interjection sentence ends with \\ &&  an exclamation mark. \\ % no-dictionary
-\textbf{?} && \textit{separator}: An questions always ends in a question mark. \\ % no-dictionary
-\textbf{:} && \textit{separator}: A colon is between an hint sentences and a sentences. \\  % no-dictionary
-\textbf{,} && \textit{separator}: A comma is used after an 'o' to address people. \\ && Optionally, it can be inserted before a preposition. \\ % no-dictionary
+\textbf{!} && \textit{separator}: An imperative or exclamatory sentence ends with \\ &&  an exclamation mark. \\ % no-dictionary
+\textbf{?} && \textit{separator}: A question always ends in a question mark. \\ % no-dictionary
+\textbf{:} && \textit{separator}: A colon goes between a hint sentence and the other sentence it refers to. \\  % no-dictionary
+\textbf{,} && \textit{separator}: A comma is used after an `o' to address people. \\ && Optionally, it can be inserted before a preposition. \\ % no-dictionary
 \end{supertabular} \\
 
 %
@@ -83,7 +81,7 @@ In these lessons, special characters are referred to as separators.
 Separators separate phrases from each other. 
 For example, a dot separates a sentence from the next sentence. 
 In Toki Pona there are also special words which serve as separators. 
-In other lessons these words are also called 'particles'.
+In other lessons these words are also called `particles'.
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -119,7 +117,7 @@ They end with an exclamation mark or a period.
 Headlines (titles) are usually not complete sentences and do not end with a punctuation mark.
 
 Please always pay attention to correct punctuation marks. 
-Wrong or missing punctuation marks impair the intelligibility.
+Wrong or missing punctuation marks impair intelligibility.
 
 %
 \newpage


### PR DESCRIPTION
toki! I learnt Toki Pona with this great book a while ago and to show my appreciation I thought it would be good to fix up typos and English grammar problems. Hopefully I will be able to do this for the whole book. I believe there were some other small problems too, such as words used in examples before they were introduced and questions being missing or different in the answers section, but I haven't got to those yet.

In some places I've reworded sentences to make them more clear or accurate, but I tried not to change what I thought the intended meaning was. I also added a couple of extra meanings to vocabulary at the start of a chapter, but nothing major. Finally, I replaced opening dumb quotes (') with grave accents (`) because otherwise it doesn't look right in the PDFs. However, after doing that I found out the grave accents remain as grave accents in the HTML, EPUB, and mobi formats. I haven't tried using actual curly quotes (‘ and ’) in the .tex files. Let me know what you want me to do in future regarding quotation marks.